### PR TITLE
setup a simple generation for the documentation OPS-63

### DIFF
--- a/.github/workflows/gendocs.yml
+++ b/.github/workflows/gendocs.yml
@@ -1,0 +1,38 @@
+name: Build and Store Documentation Artifact
+
+on:
+  push:
+    branches:
+      - master
+      - devel
+  pull_request:
+    branches:
+      - master
+      - devel
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install sphinx
+      - name: Build Sphinx documentation
+        run: |
+          cd docs
+          sphinx-apidoc -o source/_modules ../senju
+          make html
+      - name: Upload documentation artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: documentation-artifact
+          path: docs/build/html
+          # TODO: upload artifact for gh pages
+          # TODO: deploy to gh pages

--- a/.github/workflows/gendocs.yml
+++ b/.github/workflows/gendocs.yml
@@ -5,14 +5,18 @@ on:
     branches:
       - master
       - devel
-  pull_request:
-    branches:
-      - master
-      - devel
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -23,16 +27,28 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install sphinx
+          pip install sphinx poetry
+          poetry install
       - name: Build Sphinx documentation
         run: |
-          cd docs
-          sphinx-apidoc -o source/_modules ../senju
-          make html
-      - name: Upload documentation artifact
-        uses: actions/upload-artifact@v4
+          cd docs && ls
+          bash auto_docu.sh
+      - name: Upload documentation files as artifact
+        id: deployment
+        uses: actions/upload-pages-artifact@v3 # or specific "vX.X.X" version tag for this action
         with:
-          name: documentation-artifact
-          path: docs/build/html
-          # TODO: upload artifact for gh pages
-          # TODO: deploy to gh pages
+          path: docs/build/html/
+
+  deploy:
+    needs: build
+
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This automatically generates a documentation artifact when changes are made to devel or master. Also deploying them to our github-pages page. This is the same as #28 but that branch had the wrong OPS id.