### PR TITLE
fix: Changes the title of the heading for our prompt input

### DIFF
--- a/senju/templates/prompt.html
+++ b/senju/templates/prompt.html
@@ -3,7 +3,7 @@
 {% block content %}
 <div class="flex flex-col items-center justify-center min-h-screen bg-violet-900 text-white p-6">
     <div class="bg-white text-gray-900 p-8 rounded-xl shadow-lg max-w-lg w-full text-center transform transition duration-300 hover:scale-105">
-        <h1 class="text-3xl font-bold text-violet-700 mb-4">Very 1337 prompt input</h1>
+        <h1 class="text-3xl font-bold text-violet-700 mb-4">Haiku Generator</h1>
         <div class="flex flex-col gap-4">
             <input
                 type="text"


### PR DESCRIPTION
Refs: OPS-89
This pr includes just a very simple 'fix'. I changed the h1 of my frontend prompt input to 'Haiku Generator', as 'Very 1337 prompt input'  may not appear as very professional